### PR TITLE
Retry when api fails

### DIFF
--- a/lib/cuties_in_denver/adopt_a_pet.rb
+++ b/lib/cuties_in_denver/adopt_a_pet.rb
@@ -1,15 +1,19 @@
 require "net/http"
 require 'json'
 require 'open-uri'
+require 'logger'
 
 class AdoptAPet
   URL = 'http://adopt-a-pet-denver.herokuapp.com/api'
 
   def self.random
+    log = Logger.new(STDOUT)
+    log.level = Logger::INFO #set to Logger:WARN to avoid seing status messages
 
     pet = Pet.new(JSON.parse(Net::HTTP.get_response(URI.parse(URL)).body))
 
     while pet.nil? or pet.pic.nil? # just keep on trying.
+      log.info("Bummer! The server gave us either no pet or pet w/o pic! I'll try again though.")
       pet = Pet.new(JSON.parse(Net::HTTP.get_response(URI.parse(URL)).body))
       #maybe TODO later: exponential backoff rather than continuously hitting the server.
     end

--- a/lib/cuties_in_denver/adopt_a_pet.rb
+++ b/lib/cuties_in_denver/adopt_a_pet.rb
@@ -6,6 +6,15 @@ class AdoptAPet
   URL = 'http://adopt-a-pet-denver.herokuapp.com/api'
 
   def self.random
-      Pet.new(JSON.parse(Net::HTTP.get_response(URI.parse(URL)).body))
+
+    pet = Pet.new(JSON.parse(Net::HTTP.get_response(URI.parse(URL)).body))
+
+    while pet.nil? or pet.pic.nil? # just keep on trying.
+      pet = Pet.new(JSON.parse(Net::HTTP.get_response(URI.parse(URL)).body))
+      #maybe TODO later: exponential backoff rather than continuously hitting the server.
+    end
+
+    return pet
   end
+
 end


### PR DESCRIPTION
Sometimes the api server gives us an error object instead of a pet with a pic. We can just keep retrying (and log those attempts so we notice if something goes terribly wrong and we're just hitting the server endlessly).
